### PR TITLE
restore lamp state correctly on scanners

### DIFF
--- a/Verifier/Screens/Check/VerifyScannerViewController.swift
+++ b/Verifier/Screens/Check/VerifyScannerViewController.swift
@@ -24,6 +24,7 @@ class VerifyScannerViewController: ViewController {
         cameraErrorView?.alpha = 0.0
         showError(error: nil)
         qrView?.startScanning()
+        qrView?.setCameraLight(on: isLightOn)
     }
 
     // MARK: - Subviews

--- a/Wallet/Screens/Certificates/WalletScannerViewController.swift
+++ b/Wallet/Screens/Certificates/WalletScannerViewController.swift
@@ -189,6 +189,8 @@ class WalletScannerViewController: ViewController {
     private func startScanning() {
         cameraErrorView?.alpha = 0.0
         qrView?.startScanning()
+        qrView?.setCameraLight(on: isLightOn)
+
         showError(error: nil)
     }
 


### PR DESCRIPTION
The user set lamp state is now restored correctly, when the scanner is started/restarted again.