### PR TITLE
do not accept self signed certificates and execute all evalutions

### DIFF
--- a/CovidCertificate/SharedLogic/Networking/Base/URLSession+pinning.swift
+++ b/CovidCertificate/SharedLogic/Networking/Base/URLSession+pinning.swift
@@ -89,10 +89,9 @@ class CertificateEvaluator: NSObject, URLSessionDelegate {
                      "www.cc.bit.admin.ch"]
         for host in hosts {
             if let certificate = bundle.getCertificate(with: host) {
-                let evaluator = UBPinnedCertificatesTrustEvaluator(certificates: [certificate],
-                                                                   acceptSelfSignedCertificates: true,
-                                                                   performDefaultValidation: false,
-                                                                   validateHost: true)
+                // since we currently pin the Amazon Global CA we never want to accept self signed certificates in the trust-store
+                // and we also want all the default evalutions check for validity.
+                let evaluator = UBPinnedCertificatesTrustEvaluator(certificates: [certificate])
                 evaluators[host] = evaluator
             } else {
                 assertionFailure("Could not load certificate for pinned host")


### PR DESCRIPTION
We now only accept certificates, which are _not_ self signed. 

This makes bypassing TLS-Pinning for an attacker with privileged access to a device a little bit harder. Previously, one could just add a certificate to the main bundle to successfully bypass TLS-Pinning.