### PR TITLE
adds blur view when application resigns

### DIFF
--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -15,6 +15,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     internal var window: UIWindow?
     private var lastForegroundActivity: Date?
+    private var blurView: UIVisualEffectView?
 
     @UBUserDefault(key: "isFirstLaunch", defaultValue: true)
     var isFirstLaunch: Bool
@@ -106,8 +107,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func applicationDidBecomeActive(_: UIApplication) {}
-
     private func willAppearAfterColdstart(_: UIApplication, coldStart _: Bool, backgroundTime _: TimeInterval) {
         // Logic for coldstart / background
         startForceUpdateCheck()
@@ -119,6 +118,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // App should not have badges
         // Reset to 0 to ensure a unexpected badge doesn't stay forever
         application.applicationIconBadgeNumber = 0
+
+        addBlurView()
+    }
+
+    func applicationDidBecomeActive(_: UIApplication) {
+        removeBlurView()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -154,5 +159,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         UIPageControl.appearance().pageIndicatorTintColor = .cc_grey
         UIPageControl.appearance().currentPageIndicatorTintColor = .cc_black
+    }
+
+    // MARK: - Hide information on app switcher
+
+    private func removeBlurView() {
+        UIView.animate(withDuration: 0.15) {
+            self.blurView?.effect = nil
+            self.blurView?.alpha = 0.0
+        } completion: { _ in
+            self.blurView?.removeFromSuperview()
+            self.blurView = nil
+        }
+    }
+
+    private func addBlurView() {
+        blurView?.removeFromSuperview()
+
+        let bv = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        bv.frame = window?.frame ?? .zero
+        bv.isUserInteractionEnabled = false
+        window?.addSubview(bv)
+
+        blurView = bv
     }
 }

--- a/Wallet/Logic/AppDelegate.swift
+++ b/Wallet/Logic/AppDelegate.swift
@@ -15,6 +15,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
     internal var window: UIWindow?
     private var lastForegroundActivity: Date?
+    private var blurView: UIVisualEffectView?
 
     @UBUserDefault(key: "isFirstLaunch", defaultValue: true)
     var isFirstLaunch: Bool
@@ -102,8 +103,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
 
-    func applicationDidBecomeActive(_: UIApplication) {}
-
     private func willAppearAfterColdstart(_: UIApplication, coldStart _: Bool, backgroundTime _: TimeInterval) {
         // Logic for coldstart / background
         startConfigRequest()
@@ -115,6 +114,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // App should not have badges
         // Reset to 0 to ensure a unexpected badge doesn't stay forever
         application.applicationIconBadgeNumber = 0
+
+        addBlurView()
+    }
+
+    func applicationDidBecomeActive(_: UIApplication) {
+        removeBlurView()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -152,5 +157,28 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         UIPageControl.appearance().pageIndicatorTintColor = .cc_black
         UIPageControl.appearance().currentPageIndicatorTintColor = .cc_white
+    }
+
+    // MARK: - Hide information on app switcher
+
+    private func removeBlurView() {
+        UIView.animate(withDuration: 0.15) {
+            self.blurView?.effect = nil
+            self.blurView?.alpha = 0.0
+        } completion: { _ in
+            self.blurView?.removeFromSuperview()
+            self.blurView = nil
+        }
+    }
+
+    private func addBlurView() {
+        blurView?.removeFromSuperview()
+
+        let bv = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        bv.frame = window?.frame ?? .zero
+        bv.isUserInteractionEnabled = false
+        window?.addSubview(bv)
+
+        blurView = bv
     }
 }


### PR DESCRIPTION
Adds blur view when application goes to background and removes blur view when app becomes active. 

iOS is taking a screenshot when the app goes into background. This is where a blurview is added, so that the information in this screenshot is blurred. When the app is used again, this blurred view will be smoothly animated removed.