### PR TITLE
fixes flickering of homescreen on wallet start

### DIFF
--- a/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
+++ b/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
@@ -37,14 +37,14 @@ class WalletHomescreenViewController: HomescreenBaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        setupViews()
-        setupInteraction()
-
         UIStateManager.shared.addObserver(self) { [weak self] s in
             guard let strongSelf = self else { return }
             strongSelf.state = s.certificateState.certificates.count == 0 ? .onboarding : .certificates
             strongSelf.infoBox = s.infoBoxState
         }
+
+        setupViews()
+        setupInteraction()
     }
 
     // MARK: - Update


### PR DESCRIPTION
By initializing views after setting the state-observer, the views are initialized correctly.