### PR TITLE
Reference The Unlicence and MIT licence URL

### DIFF
--- a/CovidCertificate/Supporting Files/Impressum/de/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/de/licence.html
@@ -15,13 +15,14 @@
 <li>This app uses <strong>SnapKit</strong> licensed under the terms of the <strong>MIT</strong> license</li>
 <li>This app uses <strong>base45-swift</strong> licensed under the terms of the <strong>Apache 2.0</strong> license</li>
 <li>This app uses <strong>Gzip</strong> licensed under the terms of the <strong>MIT</strong> license</li>
-<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>UNLICENSED</strong> license</li>
+<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>Unlicence</strong> license</li>
 </ul>
     </div>
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="http://unlicense.org">The Unlicense</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/en/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/en/licence.html
@@ -15,13 +15,14 @@
 <li>This app uses <strong>SnapKit</strong> licensed under the terms of the <strong>MIT</strong> license</li>
 <li>This app uses <strong>base45-swift</strong> licensed under the terms of the <strong>Apache 2.0</strong> license</li>
 <li>This app uses <strong>Gzip</strong> licensed under the terms of the <strong>MIT</strong> license</li>
-<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>UNLICENSED</strong> license</li>
+<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>Unlicence</strong> license</li>
 </ul>
     </div>
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="http://unlicense.org">The Unlicense</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/fr/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/fr/licence.html
@@ -15,13 +15,14 @@
 <li>This app uses <strong>SnapKit</strong> licensed under the terms of the <strong>MIT</strong> license</li>
 <li>This app uses <strong>base45-swift</strong> licensed under the terms of the <strong>Apache 2.0</strong> license</li>
 <li>This app uses <strong>Gzip</strong> licensed under the terms of the <strong>MIT</strong> license</li>
-<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>UNLICENSED</strong> license</li>
+<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>Unlicence</strong> license</li>
 </ul>
     </div>
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="http://unlicense.org">The Unlicense</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/it/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/it/licence.html
@@ -15,13 +15,14 @@
 <li>This app uses <strong>SnapKit</strong> licensed under the terms of the <strong>MIT</strong> license</li>
 <li>This app uses <strong>base45-swift</strong> licensed under the terms of the <strong>Apache 2.0</strong> license</li>
 <li>This app uses <strong>Gzip</strong> licensed under the terms of the <strong>MIT</strong> license</li>
-<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>UNLICENSED</strong> license</li>
+<li>This app uses <strong>SwiftCBOR</strong> licensed under the terms of the <strong>Unlicence</strong> license</li>
 </ul>
     </div>
     <div class="licence-list">
     <ul>
 <li><a href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2.0 license</a></li>
-<li><a href="https://github.com/DIGGSweden/dgc-java/blob/main/LICENSE">MIT license</a></li>
+<li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
+<li><a href="http://unlicense.org">The Unlicense</a></li>
 </ul>
     </div>
 </div>


### PR DESCRIPTION
I might be totally wrong but I think you should reference to The Unlicence.
Writing that you reuse unlicenced code may lead people to think that you are doing a copyright infringement.
Also, referencing the MIT licence on the original page, although the cited one is identical, of course.