### PR TITLE
adds additional error state for certificates with invalid format

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
         "repositoryURL": "git@github.com:admin-ch/CovidCertificate-SDK-iOS.git",
         "state": {
           "branch": "main",
-          "revision": "94c56dceed6cd819bfc7a4d05091758bfa912bfa",
+          "revision": "e222450a6f497b3a22a3fc78c3a0588ee011658f",
           "version": null
         }
       },

--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -14,6 +14,7 @@ import Foundation
 
 enum VerificationError: Equatable, Comparable {
     case signature
+    case typeInvalid
     case revocation
     case expired(Date)
     case notYetValid(Date)
@@ -190,6 +191,9 @@ class Verifier: NSObject {
                 case .TRUST_SERVICE_ERROR:
                     // retry possible
                     callback(.retry(.network, [err.errorCode]))
+                case .SIGNATURE_TYPE_INVALID:
+                    // type invalid (multiple vaccines, tests
+                    callback(.invalid([.typeInvalid], [err.errorCode], nil))
                 default:
                     // error
                     callback(.invalid([.signature], [err.errorCode], nil))

--- a/Verifier/Logic/Error/VerifierErrors+CC.swift
+++ b/Verifier/Logic/Error/VerifierErrors+CC.swift
@@ -24,6 +24,8 @@ extension VerificationError {
             return UBLocalized.verifier_verifiy_error_expired
         case .notYetValid:
             return UBLocalized.verifier_verifiy_error_notyetvalid
+        case .typeInvalid:
+            return UBLocalized.verifier_error_invalid_format
         case .unknown:
             return UBLocalized.unknown_error
         }

--- a/Wallet/Logic/Error/WalletErrors+CC.swift
+++ b/Wallet/Logic/Error/WalletErrors+CC.swift
@@ -28,6 +28,9 @@ extension VerificationError {
         case let .notYetValid(date):
             let dayDate = DateFormatter.ub_dayString(from: date)
             return UBLocalized.wallet_error_valid_from.replacingOccurrences(of: "{DATE}", with: dayDate).formattingOccurrenceBold(dayDate)
+        case .typeInvalid:
+            let bold = UBLocalized.wallet_error_invalid_format_bold
+            return UBLocalized.wallet_error_invalid_format.formattingOccurrenceBold(bold)
         case .unknown:
             return UBLocalized.unknown_error.formattingOccurrenceBold("")
         }
@@ -35,7 +38,7 @@ extension VerificationError {
 
     func icon(with color: UIColor? = nil) -> UIImage? {
         switch self {
-        case .signature: return UIImage(named: "ic-info-alert")?.ub_image(with: color ?? UIColor.cc_grey)
+        case .signature, .typeInvalid: return UIImage(named: "ic-info-alert")?.ub_image(with: color ?? UIColor.cc_grey)
         case .revocation: return UIImage(named: "ic-info-alert")?.ub_image(with: color ?? UIColor.cc_grey)
         case .otherNationalRules: return UIImage(named: "ic-info-alert")?.ub_image(with: color ?? UIColor.cc_grey)
         case .expired:

--- a/Wallet/Screens/Certificates/CertificateTableViewCell.swift
+++ b/Wallet/Screens/Certificates/CertificateTableViewCell.swift
@@ -152,7 +152,7 @@ class CertificateTableViewCell: UITableViewCell {
             case let .invalid(errors, _, _):
                 if let e = errors.first {
                     switch e {
-                    case .signature, .revocation, .otherNationalRules, .unknown:
+                    case .signature, .revocation, .otherNationalRules, .unknown, .typeInvalid:
                         self.qrCodeStateImageView.image = invalid
                     case .expired:
                         self.qrCodeStateImageView.image = invalid


### PR DESCRIPTION
- updates SDK to include invalid type error when format of certificate invalid (e.g. multiple 
- adds correct error message on wallet / verifier to show error invalid format