### PR TITLE
Error display: No national rules errors displayed on Verifier

### DIFF
--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -281,9 +281,16 @@ class Verifier: NSObject {
                     // retry possible
                     callback(.retry(.noInternetConnection, [err.errorCode]))
                 case .NETWORK_PARSE_ERROR, .NETWORK_ERROR:
+                    // retry possible
                     callback(.retry(.network, [err.errorCode]))
                 default:
-                    callback(.invalid([.otherNationalRules], [err.errorCode], nil))
+                    // do not show the explicit error code on the verifier app, s.t.
+                    // no information is shown about the checked user (e.g. certificate type)
+                    #if WALLET
+                        callback(.invalid([.otherNationalRules], [err.errorCode], nil))
+                    #elseif VERIFIER
+                        callback(.invalid([.otherNationalRules], [], nil))
+                    #endif
                 }
             }
 


### PR DESCRIPTION
- Only show error codes for national rules on the Wallet app by not propagating the error code from the SDK. In this way, the verifier app never shows information about the type of certificate like "not recognized test type" or some kind of "vaccination error".