### PR TITLE
Update SDK to include Storage deserializing bug

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "92abb51f263fc6f40e76066e37986a9cbd1a6542",
+          "revision": "a0d1e439f4af190ec16cc2b5bcf5bd9a3fbd9866",
           "version": null
         }
       },


### PR DESCRIPTION
C.f. https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/38