### PR TITLE
Update SDK to improve offline mode

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "c2fdf945e7616d6edea30229e508915ff1371b03",
+          "revision": "080333d4369bf4034f314142cdcd3cfd979f526f",
           "version": null
         }
       },


### PR DESCRIPTION
This pull-request updates the SDK to improve offline-mode handling. See https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/45 for details.