### PR TITLE
Reset verifier to home screen when put into background

### DIFF
--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -123,6 +123,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         application.applicationIconBadgeNumber = 0
 
         addBlurView()
+
+        window?.rootViewController?.dismiss(animated: true, completion: nil)
     }
 
     func applicationDidBecomeActive(_: UIApplication) {

--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -124,7 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         addBlurView()
 
-        //Close all views that are currently shown, such that people can start to scan directly when opening the app the next time.
+        // Close all views that are currently shown, such that people can start to scan directly when opening the app the next time.
         window?.rootViewController?.dismiss(animated: true, completion: nil)
     }
 

--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -124,6 +124,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         addBlurView()
 
+        //Close all views that are currently shown, such that people can start to scan directly when opening the app the next time.
         window?.rootViewController?.dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
This pull-request makes sure last scanned certificate is discarded and app is reset to homescreen when the app goes to background (ready to scan new certificates)