### PR TITLE
Access security-scoped PDF resource

### DIFF
--- a/Wallet/Logic/ImportHandler/ImportHandler.swift
+++ b/Wallet/Logic/ImportHandler/ImportHandler.swift
@@ -100,6 +100,14 @@ class ImportHandler {
     }
 
     func drawImagesFromPDF(url: URL) -> [UIImage] {
+        let accessingSecurityScopedResource = url.startAccessingSecurityScopedResource()
+
+        defer {
+            if accessingSecurityScopedResource {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
         guard let document = CGPDFDocument(url as CFURL) else { return [] }
 
         var images: [UIImage] = []

--- a/Wallet/Logic/ImportHandler/ImportHandler.swift
+++ b/Wallet/Logic/ImportHandler/ImportHandler.swift
@@ -25,6 +25,14 @@ class ImportHandler {
     // MARK: - Handle URL
 
     public func handle(url: URL) {
+        let accessingSecurityScopedResource = url.startAccessingSecurityScopedResource()
+
+        defer {
+            if accessingSecurityScopedResource {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
+
         var images: [UIImage] = []
 
         if isPdf(url: url) {
@@ -100,14 +108,6 @@ class ImportHandler {
     }
 
     func drawImagesFromPDF(url: URL) -> [UIImage] {
-        let accessingSecurityScopedResource = url.startAccessingSecurityScopedResource()
-
-        defer {
-            if accessingSecurityScopedResource {
-                url.stopAccessingSecurityScopedResource()
-            }
-        }
-
         guard let document = CGPDFDocument(url as CFURL) else { return [] }
 
         var images: [UIImage] = []


### PR DESCRIPTION
Opening the PDF from an app that provides a security-scoped URL (e.g. the Files App with a file on iCloud Drive) requires a call startAccessingSecurityScopedResource to provide access to the resource.