### PR TITLE
Fix luhn alphabet

### DIFF
--- a/CovidCertificateTests/LuhnTests.swift
+++ b/CovidCertificateTests/LuhnTests.swift
@@ -22,6 +22,56 @@ final class LuhnTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func testLuhnCases() {
+        let codes = [
+            "Y8P8ECFN8",
+            "HDTYRB66W",
+            "YS6R7H88T",
+            "K42K6F7R2",
+            "3BY8DAZYS",
+            "ADWYF11SY",
+            "453S6HUA6",
+            "WR7UPHB4A",
+            "37WDPRSKM",
+            "01AWUUB2M",
+            "MA4S9CNUK",
+            "SY7M684WA",
+            "X216WN3YF",
+            "3C2YFKCNP",
+            "TNKBZ0TSK",
+            "CHARM",
+            "SW1SS9",
+            "APPS1",
+            "TRANSFERC0DET",
+        ]
+        for c in codes {
+            print(c)
+            print(Luhn.checkLuhnCode(c))
+            XCTAssertTrue(Luhn.checkLuhnCode(c))
+        }
+
+        let wrongCodes = [
+            "Y8P8ECFN9",
+            "HDTYRC66W",
+            "YS6RH788T",
+            "K43K6F7R2",
+            "3B8YDAZYS",
+            "ADWFY11SY",
+            "453S6HU6A",
+            "WR7UHPB4A",
+            "37WDRPSKM",
+            "10AWUUB2M",
+            "MAS49CNUK",
+            "SY7M864WA",
+            "$%(*(!@#$_!@*#",
+        ]
+        for c in wrongCodes {
+            print(c)
+            print(Luhn.checkLuhnCode(c))
+            XCTAssertFalse(Luhn.checkLuhnCode(c))
+        }
+    }
+
 //    func testInApp() {
 //        let iap = InAppDelivery()
 //        let expectations = expectation(description: "async task")

--- a/Wallet/Logic/Crypto/Luhn.swift
+++ b/Wallet/Logic/Crypto/Luhn.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 public enum Luhn {
-    private static let characterSet = "1234567890ABCDEFGHKMNPRSTUWXYZ".map { "\($0)" }
+    private static let characterSet = "1234567890ABCDEFHKMNPRSTUWXYZ".map { "\($0)" }
 
     private static let codeSize = 8
     public static func generateLuhnCode() -> String {
@@ -28,14 +28,26 @@ public enum Luhn {
     }
 
     public static func checkLuhnCode(_ luhnCode: String) -> Bool {
+        guard hasOnlyValidChars(luhnCode) else {
+            return false
+        }
         let sum = calculateLuhnSum(luhnCode, shouldDouble: { $0 % 2 != 0 })
         let remainder = sum % characterSet.count
         return remainder == 0
     }
 
+    private static func hasOnlyValidChars(_ luhnCode: String) -> Bool {
+        for c in luhnCode {
+            if !characterSet.contains(String(c)) {
+                return false
+            }
+        }
+        return true
+    }
+
     private static func calculateLuhnSum(_ luhnCode: String, shouldDouble: (_ index: Int) -> Bool) -> Int {
         return luhnCode.reversed().map {
-            characterSet.firstIndex(of: String($0))!
+            characterSet.firstIndex(of: String($0)) ?? 0
         }.enumerated()
             .map {
                 sum(digits: $1 * (shouldDouble($0) ? 2 : 1), withModulo: characterSet.count)


### PR DESCRIPTION
We adjust the Luhn-Alphabet to remove the "G" character. Further, we harden check sum checks to first check for invalid characters before calculating the checksum. Also we remove the force unwrap in favour of the null coalescing operator to just return something (but not crash). 

To test cross-platform compatibility we add Luhn-Codes generated and verified by the Android code. Further we introduce test cases with codes which have one permutation in it, to verify the failing. 

Last but not least an error code with bogus character is checked to ensure graceful handling.