### PR TITLE
Custom URL scheme

### DIFF
--- a/CovidCertificate/Supporting Files/Wallet-Info.plist
+++ b/CovidCertificate/Supporting Files/Wallet-Info.plist
@@ -57,7 +57,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>hcert</string>
-				<string>chcovidcert</string>
+				<string>covidcert</string>
 			</array>
 		</dict>
 	</array>

--- a/Wallet/Logic/ImportHandler/ImportHandler.swift
+++ b/Wallet/Logic/ImportHandler/ImportHandler.swift
@@ -37,9 +37,9 @@ class ImportHandler {
         if let urlComponents = NSURLComponents(url: url,
                                                resolvingAgainstBaseURL: true) {
             switch urlComponents.scheme {
-            case "hcert", "chcovidcert":
                 guard let data = Data(base64Encoded: urlComponents.host ?? ""),
                       let string = String(data: data, encoding: .utf8),
+            case "hcert", "covidcert":
                       string.starts(with: "HC1:") else { break }
                 handleMessage(message: string)
                 return true

--- a/Wallet/Logic/ImportHandler/ImportHandler.swift
+++ b/Wallet/Logic/ImportHandler/ImportHandler.swift
@@ -37,9 +37,9 @@ class ImportHandler {
         if let urlComponents = NSURLComponents(url: url,
                                                resolvingAgainstBaseURL: true) {
             switch urlComponents.scheme {
-                guard let data = Data(base64Encoded: urlComponents.host ?? ""),
-                      let string = String(data: data, encoding: .utf8),
             case "hcert", "covidcert":
+                guard let scheme = urlComponents.scheme,
+                      let string = url.absoluteString.replacingOccurrences(of: scheme + "://", with: "").removingPercentEncoding,
                       string.starts(with: "HC1:") else { break }
                 handleMessage(message: string)
                 return true


### PR DESCRIPTION
Adds handling for a custom URL-scheme. This allows other apps to transfer a certificate QR code to the wallet app.
Currently, the scheme covidcert and hcert are supported. A certificate QR code can be opened in the wallet app by creating the URL in the following format chcovidcert://URL-ENCODED(QR-Code-String)