### PR TITLE
Bugfix: Make sure Covid Certificate container is not visible in "Files" app

### DIFF
--- a/CovidCertificate/Supporting Files/Wallet-Info.plist
+++ b/CovidCertificate/Supporting Files/Wallet-Info.plist
@@ -97,7 +97,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UISupportsDocumentBrowser</key>
-	<true/>
+	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 </dict>


### PR DESCRIPTION
This hides the app from the File application. It was initially added due to an Appstore Connect warning (ITMS-90737).