### PR TITLE
Fix homescreen layout for small phones

### DIFF
--- a/Wallet/Screens/Homescreen/HomescreenBottomView.swift
+++ b/Wallet/Screens/Homescreen/HomescreenBottomView.swift
@@ -50,7 +50,7 @@ class HomescreenBottomView: UIView {
         }
 
         faqRoundView.layer.cornerRadius = r
-        faqRoundView.backgroundColor = UIColor.black.withAlphaComponent(0.1)
+        faqRoundView.backgroundColor = UIColor(ub_hexString: "#273277")?.withAlphaComponent(0.9)
 
         addSubview(stackView)
 

--- a/Wallet/Screens/Homescreen/HomescreenBottomView.swift
+++ b/Wallet/Screens/Homescreen/HomescreenBottomView.swift
@@ -50,7 +50,7 @@ class HomescreenBottomView: UIView {
         }
 
         faqRoundView.layer.cornerRadius = r
-        faqRoundView.backgroundColor = UIColor(ub_hexString: "#273277")?.withAlphaComponent(0.9)
+        faqRoundView.backgroundColor = UIColor(ub_hexString: "#203176")?.withAlphaComponent(0.9)
 
         addSubview(stackView)
 

--- a/Wallet/Screens/Homescreen/HomescreenOnboardingViewController.swift
+++ b/Wallet/Screens/Homescreen/HomescreenOnboardingViewController.swift
@@ -72,6 +72,7 @@ class HomescreenOnboardingViewController: ViewController {
         stackScrollView.addSpacerView(Padding.medium + Padding.small)
 
         stackScrollView.addArrangedView(homescreenButtons)
+        stackScrollView.addSpacerView(Padding.medium + 115)
 
         titleLabel.text = UBLocalized.wallet_certificate
         questionLabel.text = UBLocalized.wallet_homescreen_what_to_do

--- a/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
+++ b/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
@@ -188,6 +188,12 @@ class WalletHomescreenViewController: HomescreenBaseViewController {
     }
 
     private func setupViews() {
+        addSubviewController(onboardingViewController) { make in
+            make.top.equalTo(self.backgroundTopLayoutGuide)
+            make.left.right.equalToSuperview()
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide)
+        }
+
         view.addSubview(bottomView)
 
         bottomView.snp.makeConstraints { make in
@@ -199,12 +205,6 @@ class WalletHomescreenViewController: HomescreenBaseViewController {
         loadingView.backgroundColor = UIColor.clear
 
         loadingView.snp.makeConstraints { make in
-            make.top.equalTo(self.backgroundTopLayoutGuide)
-            make.left.right.equalToSuperview()
-            make.bottom.equalTo(self.bottomView.snp.top)
-        }
-
-        addSubviewController(onboardingViewController) { make in
             make.top.equalTo(self.backgroundTopLayoutGuide)
             make.left.right.equalToSuperview()
             make.bottom.equalTo(self.bottomView.snp.top)


### PR DESCRIPTION
This PR fixes the homescreen layout for small phones by putting the content below the FAQ-button and making it scrollable until it is completely above the FAQ-button.
![Simulator Screen Shot - iPhone SE (1st generation) - 2021-06-25 at 16 37 28](https://user-images.githubusercontent.com/63580776/123443200-f92a9580-d5d5-11eb-8270-df9cc1bcd25e.png)
