### PR TITLE
Set LSSupportsOpeningDocumentsInPlace to false

### DIFF
--- a/CovidCertificate/Supporting Files/Wallet-Info.plist
+++ b/CovidCertificate/Supporting Files/Wallet-Info.plist
@@ -98,6 +98,8 @@
 	</array>
 	<key>UISupportsDocumentBrowser</key>
 	<false/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<false/>
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 </dict>


### PR DESCRIPTION
As suggested by `ITMS-90737` we're adding `LSSupportsOpeningDocumentsInPlace` and setting it to false