### PR TITLE
Update SDK to latest version

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "3c3b0822ab8250021455ae268b0b0c98f91a2ae7",
+          "revision": "e27f239d6e765dce3e238cefacbe9d35edfd7325",
           "version": null
         }
       },


### PR DESCRIPTION
Update SDK to latest version which contains https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/53