### PR TITLE
Bugfix: expiration timer on small devices

### DIFF
--- a/CovidCertificate/SharedUI/Views/CertificateLightExpirationTimer.swift
+++ b/CovidCertificate/SharedUI/Views/CertificateLightExpirationTimer.swift
@@ -63,6 +63,7 @@ class CertificateLightExpirationTimer: UIView {
         timerLabel.snp.makeConstraints { make in
             make.edges.equalToSuperview().inset(UIEdgeInsets(top: Padding.small, left: 8, bottom: Padding.small, right: 8))
         }
+        timerLabel.ub_setContentPriorityRequired()
 
         backgroundColor = .cc_blueish
 


### PR DESCRIPTION
- set CertificateLightExpirationTimer height required