### PR TITLE
Bugfix: consider skipped verification state as success

### DIFF
--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -59,7 +59,7 @@ enum VerificationState: Equatable {
 
     public func isSuccess() -> Bool {
         switch self {
-        case .success:
+        case .success, .skipped:
             return true
         default:
             return false


### PR DESCRIPTION
- consider skipped verification state as success
- this fixes a bug in the [verifier.swift](https://github.com/admin-ch/CovidCertificate-App-iOS/blob/main/CovidCertificate/SharedLogic/Verifier/Verifier.swift#L192) where all verification states are checked if they are successful