### PR TITLE
Move date-of-birth ("dob") from app to SDK

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "e252c26a0d9ce8cc62fbdae0aed222eb57ef30fc",
+          "revision": "20adb2ab5f58803a4a9fec2f814808cf8810f862",
           "version": null
         }
       },

--- a/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
+++ b/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
@@ -46,16 +46,6 @@ public extension ExtensionModel {
         return [person.familyName, person.givenName].compactMap { $0 }.joined(separator: " ")
     }
 
-    var displayBirthDate: String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        if let date = dateFormatter.date(from: dateOfBirth) {
-            return DateFormatter.ub_dayString(from: date)
-        }
-
-        return dateOfBirth
-    }
-
     var displayLastName: String? {
         return person.familyName
     }

--- a/CovidCertificate/SharedUI/Views/QRCodeNameView.swift
+++ b/CovidCertificate/SharedUI/Views/QRCodeNameView.swift
@@ -118,9 +118,9 @@ class QRCodeNameView: UIView {
         switch c {
         case let .success(holder):
             nameView.text = holder.certificate.displayFullName
-            birthdayLabelView.text = holder.certificate.displayBirthDate
+            birthdayLabelView.text = holder.certificate.dateOfBirthFormatted
 
-            birthdayLabelView.accessibilityLabel = DateFormatter.ub_accessibilityDateString(dateString: holder.certificate.displayBirthDate) ?? birthdayLabelView.text
+            birthdayLabelView.accessibilityLabel = DateFormatter.ub_accessibilityDateString(dateString: holder.certificate.dateOfBirthFormatted) ?? birthdayLabelView.text
 
         case .failure:
             break

--- a/Verifier/Screens/Check/VerifyCheckContentViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckContentViewController.swift
@@ -338,7 +338,7 @@ class VerifyNameBirthdayView: UIView {
         didSet {
             nameView.titleLabel.text = holder?.displayName
             lastNameView.titleLabel.text = holder?.displayLastName
-            birthdayView.titleLabel.text = holder?.displayBirthDate
+            birthdayView.titleLabel.text = holder?.dateOfBirth
             monoLabel.text = holder?.displayMonospacedName
         }
     }

--- a/Wallet/Screens/Certificates/CertificateAddDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateAddDetailView.swift
@@ -76,8 +76,8 @@ class CertificateAddDetailView: UIView {
             switch c {
             case let .success(holder):
                 nameLabel.text = holder.certificate.displayFullName
-                birthdayLabel.text = holder.certificate.displayBirthDate
-                birthdayLabel.accessibilityLabel = DateFormatter.ub_accessibilityDateString(dateString: holder.certificate.displayBirthDate) ?? birthdayLabel.text
+                birthdayLabel.text = holder.certificate.dateOfBirthFormatted
+                birthdayLabel.accessibilityLabel = DateFormatter.ub_accessibilityDateString(dateString: holder.certificate.dateOfBirthFormatted) ?? birthdayLabel.text
             case .failure:
                 break
             }


### PR DESCRIPTION
This PR moves the dob parsing from the app to the SDK (also see https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/60)