### PR TITLE
Update sdk to latest version

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "20adb2ab5f58803a4a9fec2f814808cf8810f862",
+          "revision": "6699e1e1ee4c6c043d86c0c58e750fa9e6b0df99",
           "version": null
         }
       },


### PR DESCRIPTION
which includes: https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/61