### PR TITLE
Bugfix: Lightcertificate and PDF-export only for certificates issued by Switzerland

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "1b48c4f065e64baeb95a92e7b2b18499eed75a98",
+          "revision": "e8af8020020a4b51b0d302ac34854b8eac0b155e",
           "version": null
         }
       },


### PR DESCRIPTION
- Lightcertificates can only be created for certificates that have a valid state and were issued by Switzerland
- PDF export is enabled for certificates that were issued by Switzerland and have a valid signature