### PR TITLE
Bufix: Allow multiple transfer codes

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "1b48c4f065e64baeb95a92e7b2b18499eed75a98",
+          "revision": "3d492d705af5f3f3e4d8b90ed5565c8059332ecf",
           "version": null
         }
       },

--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "3d492d705af5f3f3e4d8b90ed5565c8059332ecf",
+          "revision": "e8af8020020a4b51b0d302ac34854b8eac0b155e",
           "version": null
         }
       },

--- a/Wallet/Logic/User/UserCertificate.swift
+++ b/Wallet/Logic/User/UserCertificate.swift
@@ -38,6 +38,17 @@ struct UserCertificate: Codable, Equatable {
 
         return .certificate
     }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        // a certificate is considerd equal if they have the same qrCode
+        if lhs.qrCode != nil,
+           rhs.qrCode != nil,
+           lhs.qrCode == rhs.qrCode {
+            return true
+        }
+        // the lightcertificate isn't compared because it is derived by the qrCode
+        return false
+    }
 }
 
 extension LightCertificate {

--- a/Wallet/Logic/User/WalletUserStorage.swift
+++ b/Wallet/Logic/User/WalletUserStorage.swift
@@ -73,7 +73,7 @@ class CertificateStorage {
     func insertCertificates(certificates: [UserCertificate]) {
         // add all certificates at the front of the list
         // that are not already added
-        let toBeAdded = certificates.filter { uc in !userCertificates.contains(where: { $0.qrCode == uc.qrCode }) }
+        let toBeAdded = certificates.filter { uc in !userCertificates.contains(uc) }
 
         if toBeAdded.count > 0 {
             userCertificates = toBeAdded + userCertificates

--- a/Wallet/Screens/TransferCode/TransferCodeDetailViewController.swift
+++ b/Wallet/Screens/TransferCode/TransferCodeDetailViewController.swift
@@ -172,7 +172,7 @@ class TransferCodeDetailViewController: ViewController {
     private func removeTransfer() {
         let alert = UIAlertController(title: nil, message: UBLocalized.wallet_transfer_delete_confirm_text, preferredStyle: .actionSheet)
         alert.addAction(UIAlertAction(title: UBLocalized.delete_button, style: .destructive, handler: { _ in
-            CertificateStorage.shared.userCertificates = CertificateStorage.shared.userCertificates.filter { $0 != self.certificate }
+            CertificateStorage.shared.userCertificates = CertificateStorage.shared.userCertificates.filter { $0.transferCode != self.certificate.transferCode }
             self.dismiss(animated: true, completion: nil)
         }))
         alert.addAction(UIAlertAction(title: UBLocalized.cancel_button, style: .cancel, handler: nil))


### PR DESCRIPTION
Currently, a new created transfer code overwrites the existing one