### PR TITLE
Minor accessbility fixes

### DIFF
--- a/CovidCertificate/Supporting Files/Impressum/de/impressum.html
+++ b/CovidCertificate/Supporting Files/Impressum/de/impressum.html
@@ -74,7 +74,7 @@
     <div class="divider"></div>
 
     <a href="ccert://licence.html" class="licence-link">
-        <h1>Lizenzen</h1>
+        <h1 role="none">Lizenzen</h1>
         <picture>
             <img src="../img/ic-arrow.svg" alt="">
         </picture>

--- a/CovidCertificate/Supporting Files/Impressum/en/impressum.html
+++ b/CovidCertificate/Supporting Files/Impressum/en/impressum.html
@@ -25,7 +25,7 @@
         www.bag.admin.ch
     </a>
 
-    <h2>Infoline Coronavirus</h2>
+    <h2>Coronavirus Infoline</h2>
     <a class="link" href="tel:&#43;41584630000">
         <img src="../img/ic-call.svg" alt="">
         &#43;41 58 463 00 00
@@ -34,7 +34,7 @@
     <h2>Legal</h2>
     <a class="link" href="{LAW_LINK}">
         <img src="../img/ic-link-external.svg" alt="">
-        Data Protection Statement &amp; Conditions of Use
+        Privacy policy &amp; Terms of use
     </a>
 
     <div class="divider"></div>
@@ -74,7 +74,7 @@
     <div class="divider"></div>
 
     <a href="ccert://licence.html" class="licence-link">
-        <h1>Licences</h1>
+        <h1 role="none">Licences</h1>
         <picture>
             <img src="../img/ic-arrow.svg" alt="">
         </picture>

--- a/CovidCertificate/Supporting Files/Impressum/fr/impressum.html
+++ b/CovidCertificate/Supporting Files/Impressum/fr/impressum.html
@@ -74,7 +74,7 @@
     <div class="divider"></div>
 
     <a href="ccert://licence.html" class="licence-link">
-        <h1>Licences</h1>
+        <h1 role="none">Licences</h1>
         <picture>
             <img src="../img/ic-arrow.svg" alt="">
         </picture>

--- a/CovidCertificate/Supporting Files/Impressum/it/impressum.html
+++ b/CovidCertificate/Supporting Files/Impressum/it/impressum.html
@@ -74,7 +74,7 @@
     <div class="divider"></div>
 
     <a href="ccert://licence.html" class="licence-link">
-        <h1>Licenze</h1>
+        <h1 role="none">Licenze</h1>
         <picture>
             <img src="../img/ic-arrow.svg" alt="">
         </picture>

--- a/CovidCertificate/Supporting Files/Impressum/rm/impressum.html
+++ b/CovidCertificate/Supporting Files/Impressum/rm/impressum.html
@@ -74,7 +74,7 @@
     <div class="divider"></div>
 
     <a href="ccert://licence.html" class="licence-link">
-        <h1>Licenzas</h1>
+        <h1 role="none">Licenzas</h1>
         <picture>
             <img src="../img/ic-arrow.svg" alt="">
         </picture>


### PR DESCRIPTION
The imprint license `h1` is actually a link, therefor the role has to be set to none.