### PR TITLE
Fixes issues in certificate comparison

### DIFF
--- a/Wallet/Logic/User/UserCertificate.swift
+++ b/Wallet/Logic/User/UserCertificate.swift
@@ -38,17 +38,6 @@ struct UserCertificate: Codable, Equatable {
 
         return .certificate
     }
-
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        // a certificate is considerd equal if they have the same qrCode
-        if lhs.qrCode != nil,
-           rhs.qrCode != nil,
-           lhs.qrCode == rhs.qrCode {
-            return true
-        }
-        // the lightcertificate isn't compared because it is derived by the qrCode
-        return false
-    }
 }
 
 extension LightCertificate {

--- a/Wallet/Logic/User/WalletUserStorage.swift
+++ b/Wallet/Logic/User/WalletUserStorage.swift
@@ -73,7 +73,15 @@ class CertificateStorage {
     func insertCertificates(certificates: [UserCertificate]) {
         // add all certificates at the front of the list
         // that are not already added
-        let toBeAdded = certificates.filter { uc in !userCertificates.contains(uc) }
+        let toBeAdded = certificates.filter { uc in !userCertificates.contains(where: {
+            if $0.qrCode == uc.qrCode, $0.qrCode != nil {
+                return true
+            }
+            if $0.transferCode == uc.transferCode, $0.transferCode != nil {
+                return false
+            }
+            return false
+        }) }
 
         if toBeAdded.count > 0 {
             userCertificates = toBeAdded + userCertificates

--- a/Wallet/Screens/Certificates/CertificateAddDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateAddDetailView.swift
@@ -57,7 +57,7 @@ class CertificateAddDetailView: UIView {
         stackScrollView.addSpacerView(Padding.large + Padding.medium)
 
         if let cert = certificate {
-            if CertificateStorage.shared.userCertificates.contains(cert) {
+            if CertificateStorage.shared.userCertificates.contains(where: { $0.qrCode == cert.qrCode }) {
                 stackScrollView.addSpacerView(Padding.medium)
                 stackScrollView.addArrangedView(CertificateAlreadyAddedView())
             }


### PR DESCRIPTION
Fixes an issue in certificate comparison introduced with https://github.com/admin-ch/CovidCertificate-App-iOS/pull/145.
The whole Usercertificate object has to be compared in order for the observer to be triggered.