### PR TITLE
Fixes certificate check after expired transfer code

### DIFF
--- a/Wallet/Screens/Homescreen/HomescreenCertificatesViewController.swift
+++ b/Wallet/Screens/Homescreen/HomescreenCertificatesViewController.swift
@@ -112,10 +112,9 @@ class HomescreenCertificatesViewController: ViewController {
                 VerifierManager.shared.addObserver(self, for: qrCode) { [weak i] state in
                     i?.state = state
                 }
-            } else if let transferCode = i.certificate?.transferCode {
-                // only start when not already failed
-                guard transferCode.state != .failed else { return }
-
+            } else if let transferCode = i.certificate?.transferCode,
+                      transferCode.state != .failed // only start when not already failed
+            {
                 TransferManager.shared.addObserver(self, for: transferCode.transferCode) { [weak i] result in
                     guard let strongI = i else { return }
                     switch result {


### PR DESCRIPTION
The return in the guard prevented further verifier checks from being executed on the homescreen.