### PR TITLE
Remove arrow in IconImageRow

### DIFF
--- a/CovidCertificate/SharedUI/Views/IconImageRowView.swift
+++ b/CovidCertificate/SharedUI/Views/IconImageRowView.swift
@@ -79,7 +79,7 @@ class IconImageRowView: UIControl {
 
         set(enabled) {
             super.isEnabled = enabled
-            arrowView.image = arrowView.image?.ub_image(with: enabled ? .cc_blue : .cc_grey)
+            arrowView.ub_setHidden(!enabled)
             iconView.image = iconView.image?.ub_image(with: enabled ? .cc_blue : .cc_grey)
             label.textColor = enabled ? .cc_blue : .cc_grey
         }


### PR DESCRIPTION
In the disabled state, remove the arrow as designed. It's clearer that you cannot click the disabled buttons.