### PR TITLE
Update SDK (which unifies manufacturer and test name) and display as one element

### DIFF
--- a/CovidCertificate.xcodeproj/project.pbxproj
+++ b/CovidCertificate.xcodeproj/project.pbxproj
@@ -2672,7 +2672,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/admin-ch/CovidCertificate-SDK-iOS";
 			requirement = {
-				branch = main;
+				branch = "feature/manufactor-and-name";
 				kind = branch;
 			};
 		};

--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
         "package": "CovidCertificateSDK",
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
-          "branch": "main",
-          "revision": "b83cb268402f126bf08321299892b5393ab2fb56",
+          "branch": "feature/manufactor-and-name",
+          "revision": "88407956959a46e35d4b91130c475660580dc842",
           "version": null
         }
       },

--- a/Translations/Strings+Generated.swift
+++ b/Translations/Strings+Generated.swift
@@ -264,6 +264,8 @@ import Foundation
      case wallet_certificate_delete_confirm_text_key = "wallet_certificate_delete_confirm_text"
     /// Zertifikat Light
      case wallet_certificate_detail_certificate_light_button_key = "wallet_certificate_detail_certificate_light_button"
+    /// Date format used: dd.mm.yyyy
+     case wallet_certificate_detail_date_format_info_key = "wallet_certificate_detail_date_format_info"
     /// Exportieren
      case wallet_certificate_detail_export_button_key = "wallet_certificate_detail_export_button"
     /// Dieses Zertifikat ist kein Reisedokument. \n\nDie wissenschaftlichen Erkenntnisse über Covid-19-Impfungen und -Tests sowie über die Genesung von einer Covid-19-Infektion entwickeln sich ständig weiter, auch im Hinblick auf neue besorgniserregende Virusvarianten. \n\nBitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmassnahmen und damit verbundenen Beschränkungen.
@@ -362,6 +364,8 @@ import Foundation
      case wallet_certificate_test_done_by_key = "wallet_certificate_test_done_by"
     /// Hersteller
      case wallet_certificate_test_holder_key = "wallet_certificate_test_holder"
+    /// Hersteller/ Name
+     case wallet_certificate_test_holder_and_name_key = "wallet_certificate_test_holder_and_name"
     /// Land des Tests
      case wallet_certificate_test_land_key = "wallet_certificate_test_land"
     /// Name
@@ -982,6 +986,8 @@ import Foundation
    static let wallet_certificate_delete_confirm_text = UBLocalized.tr(UBLocalizedKey.wallet_certificate_delete_confirm_text_key)
   /// Zertifikat Light
    static let wallet_certificate_detail_certificate_light_button = UBLocalized.tr(UBLocalizedKey.wallet_certificate_detail_certificate_light_button_key)
+  /// Date format used: dd.mm.yyyy
+   static let wallet_certificate_detail_date_format_info = UBLocalized.tr(UBLocalizedKey.wallet_certificate_detail_date_format_info_key)
   /// Exportieren
    static let wallet_certificate_detail_export_button = UBLocalized.tr(UBLocalizedKey.wallet_certificate_detail_export_button_key)
   /// Dieses Zertifikat ist kein Reisedokument. \n\nDie wissenschaftlichen Erkenntnisse über Covid-19-Impfungen und -Tests sowie über die Genesung von einer Covid-19-Infektion entwickeln sich ständig weiter, auch im Hinblick auf neue besorgniserregende Virusvarianten. \n\nBitte informieren Sie sich vor der Reise über die am Zielort geltenden Gesundheitsmassnahmen und damit verbundenen Beschränkungen.
@@ -1080,6 +1086,8 @@ import Foundation
    static let wallet_certificate_test_done_by = UBLocalized.tr(UBLocalizedKey.wallet_certificate_test_done_by_key)
   /// Hersteller
    static let wallet_certificate_test_holder = UBLocalized.tr(UBLocalizedKey.wallet_certificate_test_holder_key)
+  /// Hersteller/ Name
+   static let wallet_certificate_test_holder_and_name = UBLocalized.tr(UBLocalizedKey.wallet_certificate_test_holder_and_name_key)
   /// Land des Tests
    static let wallet_certificate_test_land = UBLocalized.tr(UBLocalizedKey.wallet_certificate_test_land_key)
   /// Name

--- a/Translations/de.lproj/Localizable.strings
+++ b/Translations/de.lproj/Localizable.strings
@@ -887,6 +887,7 @@
 "wallet_certificate_light_detail_text_2_bold" = "nur muss keine";
 
 /*VoiceOver reads this when the expandable box is reduced*/
+/*Fuzzy*/
 "accessibility_expandable_box_reduced_state" = "reduziert";
 
 /*VoiceOver reads this when the expandable box is expanded*/
@@ -964,3 +965,8 @@
 
 /*Einstellungen: Titel Sprachauswahl*/
 "language_title" = "Sprache";
+
+/*Information about the date format (always english)*/
+/*Fuzzy*/
+"wallet_certificate_detail_date_format_info" = "Date format used: dd.mm.yyyy";
+"wallet_certificate_test_holder_and_name" = "Hersteller/ Name";

--- a/Translations/en.lproj/Localizable.strings
+++ b/Translations/en.lproj/Localizable.strings
@@ -724,7 +724,7 @@
 "wallet_faq_works_question_3_1" = "Can I use the app offline?";
 "wallet_faq_works_answer_3_1" = "You can use the app without an internet connection, so you can still call up your certificates and present them for scanning and verification.\n\nHowever, in order to show whether your certificate meets Switzerland’s validity criteria and how long it is valid for, the COVID Certificate app has to be online at regular intervals.";
 "verifier_faq_works_question_2_1" = "What are the current validity criteria in Switzerland?";
-"verifier_faq_works_answer_2_1" = "The current validity period of Covid certificates can be found here:";
+"verifier_faq_works_answer_2_1" = "The current validity period of COVID certificates can be found here:";
 "verifier_faq_works_linktext_2_1" = "Further information";
 "verifier_faq_works_linkurl_2_1" = "https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/covid-zertifikat.html#-837133624";
 "verifier_faq_works_question_7" = "Is it possible to verify the certificates offline?";
@@ -861,9 +861,11 @@
 "wallet_certificate_light_detail_text_2_bold" = "only has to does not";
 
 /*VoiceOver reads this when the expandable box is reduced*/
+/*Fuzzy*/
 "accessibility_expandable_box_reduced_state" = "reduced";
 
 /*VoiceOver reads this when the expandable box is expanded*/
+/*Fuzzy*/
 "accessibility_expandable_box_expanded_state" = "expanded";
 
 /*Header im Update Boarding-Screen*/
@@ -936,3 +938,8 @@
 
 /*Einstellungen: Titel Sprachauswahl*/
 "language_title" = "Language";
+
+/*Information about the date format (always english)*/
+/*Fuzzy*/
+"wallet_certificate_detail_date_format_info" = "Date format used: dd.mm.yyyy";
+"wallet_certificate_test_holder_and_name" = "Manufacturer/ Name";

--- a/Translations/fr.lproj/Localizable.strings
+++ b/Translations/fr.lproj/Localizable.strings
@@ -861,9 +861,11 @@
 "wallet_certificate_light_detail_text_2_bold" = "n’est utilisable qu’en doit être aucun";
 
 /*VoiceOver reads this when the expandable box is reduced*/
+/*Fuzzy*/
 "accessibility_expandable_box_reduced_state" = "réduit";
 
 /*VoiceOver reads this when the expandable box is expanded*/
+/*Fuzzy*/
 "accessibility_expandable_box_expanded_state" = "étendu";
 
 /*Header im Update Boarding-Screen*/
@@ -936,3 +938,8 @@
 
 /*Einstellungen: Titel Sprachauswahl*/
 "language_title" = "Langue";
+
+/*Information about the date format (always english)*/
+/*Fuzzy*/
+"wallet_certificate_detail_date_format_info" = "Date format used: dd.mm.yyyy";
+"wallet_certificate_test_holder_and_name" = "Fabricant/ Nom";

--- a/Translations/it.lproj/Localizable.strings
+++ b/Translations/it.lproj/Localizable.strings
@@ -861,9 +861,11 @@
 "wallet_certificate_light_detail_text_2_bold" = "solamente deve alcun";
 
 /*VoiceOver reads this when the expandable box is reduced*/
+/*Fuzzy*/
 "accessibility_expandable_box_reduced_state" = "compressa";
 
 /*VoiceOver reads this when the expandable box is expanded*/
+/*Fuzzy*/
 "accessibility_expandable_box_expanded_state" = "espansa";
 
 /*Header im Update Boarding-Screen*/
@@ -936,3 +938,8 @@
 
 /*Einstellungen: Titel Sprachauswahl*/
 "language_title" = "Lingua";
+
+/*Information about the date format (always english)*/
+/*Fuzzy*/
+"wallet_certificate_detail_date_format_info" = "Date format used: dd.mm.yyyy";
+"wallet_certificate_test_holder_and_name" = "Fabbricante/ Nome";

--- a/Translations/rm.lproj/Localizable.strings
+++ b/Translations/rm.lproj/Localizable.strings
@@ -48,7 +48,7 @@
 "wallet_add_certificate" = "Agiuntar";
 
 /*Wallet: Homescreen Covid-Zertifikat*/
-"wallet_certificate" = "Certificat covid";
+"wallet_certificate" = "Certificat COVID";
 
 /*Wallet: Homescreen Erklärung*/
 "wallet_homescreen_explanation" = "Scannai il code QR sin il certificat COVID per al agiuntar a l'app.";
@@ -861,9 +861,11 @@
 "wallet_certificate_light_detail_text_2_bold" = "mo danovamain nagins";
 
 /*VoiceOver reads this when the expandable box is reduced*/
+/*Fuzzy*/
 "accessibility_expandable_box_reduced_state" = "reducì";
 
 /*VoiceOver reads this when the expandable box is expanded*/
+/*Fuzzy*/
 "accessibility_expandable_box_expanded_state" = "extendì";
 
 /*Header im Update Boarding-Screen*/
@@ -936,3 +938,8 @@
 
 /*Einstellungen: Titel Sprachauswahl*/
 "language_title" = "Lingua";
+
+/*Information about the date format (always english)*/
+/*Fuzzy*/
+"wallet_certificate_detail_date_format_info" = "Date format used: dd.mm.yyyy";
+"wallet_certificate_test_holder_and_name" = "Producent/ Num";

--- a/Wallet/Screens/Certificates/CertificateDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailView.swift
@@ -180,8 +180,7 @@ class CertificateDetailView: UIView {
             addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_result_title_key), value: text)
 
             addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_type_key), value: test.testType)
-            addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_name_key), value: test.testName)
-            addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_holder_key), value: test.manufacturer)
+            addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_holder_and_name_key), value: test.manufacturerAndTestName)
 
             addDividerLine()
 


### PR DESCRIPTION
This pull-request updates to SDK and displays the manufacturer and test name for RAT tests in one element (from "ma" only). 

Do not merge until https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/90 is merged. 