### PR TITLE
Faster scanning after going to background

### DIFF
--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -143,8 +143,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         addBlurView()
 
-        // Close all views that are currently shown, such that people can start to scan directly when opening the app the next time.
-        window?.rootViewController?.dismiss(animated: true, completion: nil)
+        // if the presented view controller is a VerifyViewController, we only dismiss the result
+        // such that the scanner is directly available without a click
+        if let pvc = window?.rootViewController?.presentedViewController as? VerifyViewController {
+            pvc.dismissResult()
+        } else {
+            window?.rootViewController?.dismiss(animated: true, completion: nil)
+        }
     }
 
     func applicationDidBecomeActive(_: UIApplication) {

--- a/Verifier/Screens/Check/VerifyCheckViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckViewController.swift
@@ -148,6 +148,10 @@ class VerifyCheckViewController: ViewController {
         }
     }
 
+    public func dismissResult() {
+        checkContentViewController.okButtonTouchUpCallback?()
+    }
+
     // MARK: - Update
 
     private func updateBackground(_ animated: Bool) {

--- a/Verifier/Screens/Check/VerifyViewController.swift
+++ b/Verifier/Screens/Check/VerifyViewController.swift
@@ -38,6 +38,10 @@ class VerifyViewController: ViewController {
         checkViewController.view.isUserInteractionEnabled = false
     }
 
+    public func dismissResult() {
+        checkViewController.dismissResult()
+    }
+
     private func setupInteraction() {
         scannerViewController.scanningSucceededCallback = { [weak self] holder in
             guard let strongSelf = self else { return }


### PR DESCRIPTION
https://github.com/admin-ch/CovidCertificate-App-iOS/issues/169

This would be a solution to scan faster after going to a different app. If the user is already scanning, we just dismiss the last visible result.