### PR TITLE
Make certificate pdf export name unique

### DIFF
--- a/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
+++ b/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
@@ -57,6 +57,15 @@ public extension ExtensionModel {
     var displayMonospacedName: String? {
         return [person.standardizedFamilyName, person.standardizedGivenName].compactMap { $0 }.joined(separator: "<<")
     }
+
+    var sharePDFName: String? {
+        guard let certificate = self as? DCCCert else { return nil }
+        let name = [certificate.person.familyName, certificate.person.givenName].compactMap { $0 }.joined(separator: "-")
+        guard let uvic: String = certificate.vaccinations?.first?.certificateIdentifier ??
+            certificate.pastInfections?.first?.certificateIdentifier ??
+            certificate.tests?.first?.certificateIdentifier else { return nil }
+        return "covid-certificate-\(name)-\(uvic.suffix(4)).pdf"
+    }
 }
 
 extension Vaccination {

--- a/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
+++ b/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
@@ -59,6 +59,7 @@ public extension ExtensionModel {
     }
 
     var sharePDFName: String? {
+        // only DCCCerts should get exported
         guard let certificate = self as? DCCCert else { return nil }
         let name = [certificate.person.familyName, certificate.person.givenName].compactMap { $0 }.joined(separator: "-")
         guard let uvic: String = certificate.vaccinations?.first?.certificateIdentifier ??

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -207,7 +207,14 @@ class CertificateDetailViewController: ViewController {
                 guard let self = self else { return }
                 self.certificate = certificate
                 guard let pdf = certificate.pdf else { return }
-                self.sharePDF(pdf)
+                let c = CovidCertificateSDK.Wallet.decode(encodedData: certificate.qrCode ?? "")
+                switch c {
+                case let .success(holder):
+                    guard let filename = holder.certificate.sharePDFName else { return }
+                    self.sharePDF(pdf, filename: filename)
+                case .failure:
+                    break
+                }
             }
             strongSelf.navigationController?.pushViewController(vc, animated: true)
         }
@@ -219,8 +226,8 @@ class CertificateDetailViewController: ViewController {
         startCheck()
     }
 
-    private func sharePDF(_ pdf: Data) {
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent("\(UBLocalized.covid_certificate_title).pdf")
+    private func sharePDF(_ pdf: Data, filename: String) {
+        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
         try? pdf.write(to: fileURL)
 
         let activityViewController: UIActivityViewController = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)


### PR DESCRIPTION
Previously all exported certificates were named equally this cause some confusion. This PR makes the exported filename unique. 
The PDF are now named "covid-certificate-{last name}-{first name}-{last 4 characters of uvci}.pdf"