### PR TITLE
Migrate private key to keychain

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,124 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "base45-swift",
+        "repositoryURL": "https://github.com/ehn-digital-green-development/base45-swift",
+        "state": {
+          "branch": "main",
+          "revision": "b2fd6c1ff48f6ea1d2877368afd326700427f261",
+          "version": null
+        }
+      },
+      {
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/Kitura/BlueCryptor.git",
+        "state": {
+          "branch": null,
+          "revision": "ee5880e031da4c609f372cf7472476ab51d5dd19",
+          "version": "1.0.200"
+        }
+      },
+      {
+        "package": "CryptorECC",
+        "repositoryURL": "https://github.com/Kitura/BlueECC.git",
+        "state": {
+          "branch": null,
+          "revision": "baf6ed3fc1a622675f0041b4aff7c02dd1a93818",
+          "version": "1.2.200"
+        }
+      },
+      {
+        "package": "CryptorRSA",
+        "repositoryURL": "https://github.com/Kitura/BlueRSA.git",
+        "state": {
+          "branch": null,
+          "revision": "440f78db26d8bb073f29590f1c7bd31004da09ae",
+          "version": "1.0.201"
+        }
+      },
+      {
+        "package": "CovidCertificateSDK",
+        "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
+        "state": {
+          "branch": "main",
+          "revision": "1c9a15cbbd7a9038187a4fa544600cc02da86aab",
+          "version": null
+        }
+      },
+      {
+        "package": "Gzip",
+        "repositoryURL": "https://github.com/1024jp/GzipSwift",
+        "state": {
+          "branch": null,
+          "revision": "ba0b6cb51cc6202f896e469b87d2889a46b10d1b",
+          "version": "5.1.1"
+        }
+      },
+      {
+        "package": "jsonlogic",
+        "repositoryURL": "https://github.com/eu-digital-green-certificates/json-logic-swift",
+        "state": {
+          "branch": null,
+          "revision": "e59a317e03491abe1f04c87b965a52abae243ddd",
+          "version": "1.1.8"
+        }
+      },
+      {
+        "package": "KituraContracts",
+        "repositoryURL": "https://github.com/Kitura/KituraContracts.git",
+        "state": {
+          "branch": null,
+          "revision": "8418006e39e2efae9b31ae92721cb597ac29c617",
+          "version": "1.2.200"
+        }
+      },
+      {
+        "package": "LoggerAPI",
+        "repositoryURL": "https://github.com/Kitura/LoggerAPI.git",
+        "state": {
+          "branch": null,
+          "revision": "e82d34eab3f0b05391082b11ea07d3b70d2f65bb",
+          "version": "1.9.200"
+        }
+      },
+      {
+        "package": "SnapKit",
+        "repositoryURL": "https://github.com/SnapKit/SnapKit",
+        "state": {
+          "branch": null,
+          "revision": "d458564516e5676af9c70b4f4b2a9178294f1bc6",
+          "version": "5.0.1"
+        }
+      },
+      {
+        "package": "SwiftJWT",
+        "repositoryURL": "https://github.com/Kitura/Swift-JWT.git",
+        "state": {
+          "branch": null,
+          "revision": "2f2fc12ae88660e0760b04d9e6c341517b31ad7b",
+          "version": "3.6.200"
+        }
+      },
+      {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "SwiftCBOR",
+        "repositoryURL": "https://github.com/eu-digital-green-certificates/SwiftCBOR",
+        "state": {
+          "branch": "master",
+          "revision": "642e9e93fb4a51b564c1bf21bf3c5b4c6bc79416",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Wallet/Logic/AppDelegate.swift
+++ b/Wallet/Logic/AppDelegate.swift
@@ -29,6 +29,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // migrates certificates from keychain to secure storage
         Migration.migrateToSecureStorage()
 
+        // migrate certificate key to keychain without secure enclave
+        Migration.migrateToSecureStorageWithoutSecureEnclave()
+
         // Pre-populate isFirstLaunch for users which already installed the app before we introduced this flag
         if WalletUserStorage.shared.hasCompletedOnboarding {
             isFirstLaunch = false

--- a/Wallet/Logic/User/Migration.swift
+++ b/Wallet/Logic/User/Migration.swift
@@ -29,5 +29,20 @@ class Migration {
         CertificateStorage.shared.keyChainUserCertificates = []
 
         WalletUserStorage.shared.hasCompletedSecureStorageMigration = true
+
+        // if key is newly generated we dont have migrate to keychain without secure enclave
+        WalletUserStorage.shared.hasCompletedSecureStorageMigrationWithoutSecureEnclave = true
+    }
+
+    static func migrateToSecureStorageWithoutSecureEnclave() {
+        // previously the key to encrypt the secure storage was on the secure enclave
+        // due to this on backup restoration all certificates were lost
+        guard !WalletUserStorage.shared.hasCompletedSecureStorageMigrationWithoutSecureEnclave else {
+            return
+        }
+
+        CertificateStorage.shared.forceSave()
+
+        WalletUserStorage.shared.hasCompletedSecureStorageMigrationWithoutSecureEnclave = true
     }
 }

--- a/Wallet/Logic/User/SecureStorage/Enclave.swift
+++ b/Wallet/Logic/User/SecureStorage/Enclave.swift
@@ -50,7 +50,7 @@ public enum Enclave {
         else {
             return (nil, error?.takeRetainedValue().localizedDescription)
         }
-        var attributes: [String: Any] = [
+        let attributes: [String: Any] = [
             kSecAttrKeyType as String: kSecAttrKeyTypeEC,
             kSecAttrKeySizeInBits as String: 256,
             kSecPrivateKeyAttrs as String: [
@@ -59,9 +59,6 @@ public enum Enclave {
                 kSecAttrAccessControl as String: access,
             ],
         ]
-        #if !targetEnvironment(simulator)
-            attributes[kSecAttrTokenID as String] = kSecAttrTokenIDSecureEnclave
-        #endif
         guard
             let privateKey = SecKeyCreateRandomKey(
                 attributes as CFDictionary,

--- a/Wallet/Logic/User/SecureStorage/SecureStorage.swift
+++ b/Wallet/Logic/User/SecureStorage/SecureStorage.swift
@@ -40,13 +40,17 @@ public struct SecureStorage<T: Codable> {
         create: true
     )
     var path: URL! { URL(string: documents.absoluteString + name) }
+    let oldKey: SecKey?
     let secureStorageKey: SecKey?
 
     let name: String
 
     public init(name: String) {
         self.name = name
-        secureStorageKey = Enclave.loadOrGenerateKey(with: "\(name)_secureStorageKey")
+        // this is the key which was previously used to encrypt the storage
+        oldKey = Enclave.loadOrGenerateKey(with: "\(name)_secureStorageKey")
+        // this is the new key, since keychain attributes have changed we had to create a new key
+        secureStorageKey = Enclave.loadOrGenerateKey(with: "\(name)_secureStorageKey_1")
     }
 
     public func loadSynchronously() -> T? {
@@ -54,13 +58,23 @@ public struct SecureStorage<T: Codable> {
             return nil
         }
 
-        guard
-            let (data, signature) = read(),
-            let key = secureStorageKey,
-            Enclave.verify(data: data, signature: signature, with: key).0
-        else {
-            return nil
+        var key = secureStorageKey
+
+        guard let (data, signature) = read() else { return nil }
+
+        if let unwrappedKey = key,
+           !Enclave.verify(data: data, signature: signature, with: unwrappedKey).0 {
+            // if the data is not decryptable with the new key try to decrypt it with the old one
+            // this fallback ensures that we always can decrypt the saved data
+            // On the next save it will get encrypted with the ney key
+            key = oldKey
+            guard let unwrappedOldKey = key,
+                  Enclave.verify(data: data, signature: signature, with: unwrappedOldKey).0 else {
+                return nil
+            }
         }
+
+        guard let key = key else { return nil }
 
         let semaphore = DispatchSemaphore(value: 0)
         var t: T?

--- a/Wallet/Logic/User/WalletUserStorage.swift
+++ b/Wallet/Logic/User/WalletUserStorage.swift
@@ -27,6 +27,9 @@ class WalletUserStorage {
     @UBUserDefault(key: "wallet.user.hasCompletedSecureStorageMigration", defaultValue: false)
     var hasCompletedSecureStorageMigration: Bool
 
+    @UBUserDefault(key: "wallet.user.hasCompletedSecureStorageMigrationWithoutSecureEnclave", defaultValue: false)
+    var hasCompletedSecureStorageMigrationWithoutSecureEnclave: Bool
+
     @UBUserDefault(key: "wallet.user.hasCompletedPushRegistration", defaultValue: false)
     var hasCompletedPushRegistration: Bool
 
@@ -170,6 +173,11 @@ class CertificateStorage {
 
     func removeAll() {
         userCertificates = []
+    }
+
+    /// certififcates are automatically saved on chages, this method forces a synchronous save
+    func forceSave() {
+        _ = secureStorage.saveSynchronously(certificates)
     }
 
     // MARK: - Migration


### PR DESCRIPTION
Previously the key which was used to encrypt the local storage was stored in the secure enclave and therefore it was not possible to restore certificates from an encrypted backup. This PR removed the `kSecAttrTokenIDSecureEnclave`attribute and adds a migration for the existing data.