### PR TITLE
Fixes problems with view hierarchy on Wallet homescreen with VoiceOver

### DIFF
--- a/CovidCertificate/SharedUI/Base/HomescreenBaseViewController.swift
+++ b/CovidCertificate/SharedUI/Base/HomescreenBaseViewController.swift
@@ -135,7 +135,7 @@ class HomescreenBaseViewController: ViewController {
 
     private func presentInfoBox() {
         boxView.infoBox = infoBox
-        boxView.presentFrom(view: infoBoxButton)
+        boxView.presentFrom(view: infoBoxButton, isPresentedFromCloseButton: true)
     }
 
     private func dismissInfoBox() {

--- a/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
+++ b/Wallet/Screens/Homescreen/WalletHomescreenViewController.swift
@@ -172,7 +172,7 @@ class WalletHomescreenViewController: HomescreenBaseViewController {
             if strongSelf.actionViewIsShown {
                 strongSelf.actionPopupView.dismiss()
             } else {
-                strongSelf.actionPopupView.presentFrom(view: strongSelf.addCertificateButton)
+                strongSelf.actionPopupView.presentFrom(view: strongSelf.addCertificateButton, isPresentedFromCloseButton: true)
             }
         }
 
@@ -183,8 +183,6 @@ class WalletHomescreenViewController: HomescreenBaseViewController {
             UIView.animate(withDuration: 0.25, delay: 0.0, options: [.curveEaseInOut]) {
                 strongSelf.addCertificateButton.transform = CGAffineTransform(rotationAngle: show ? CGFloat.pi * 0.25 : 0.0)
             } completion: { _ in }
-
-            UIAccessibility.post(notification: .layoutChanged, argument: show ? strongSelf.actionPopupView : nil)
         }
 
         infoButtonCallback = { [weak self] in


### PR DESCRIPTION
This PR fixes problems on the Wallet homescreen when VoiceOver is turned on. By showing the PopupView with accessibilityViewIsModal, these problems are fixed.
- Fixes problem that FAQ-button can be reached when action view to add certificate is shown
- Fixes problem that homescreen can be reached when InfoBox/Push-Popup is presented