### PR TITLE
Delete all keychain keys on first app start

### DIFF
--- a/Wallet/Logic/AppDelegate.swift
+++ b/Wallet/Logic/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if isFirstLaunch {
             CertificateStorage.shared.removeAll()
             Keychain().deleteAll()
+            Enclave.deleteAllKeys()
             isFirstLaunch = false
         }
 

--- a/Wallet/Logic/User/SecureStorage/Enclave.swift
+++ b/Wallet/Logic/User/SecureStorage/Enclave.swift
@@ -217,4 +217,21 @@ public enum Enclave {
         }
         return (signature, err)
     }
+
+    /// Deletes all keys from the keychain
+    /// - Returns: a result true if successful
+    @discardableResult
+    public static func deleteAllKeys() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassKey as String,
+        ]
+
+        let status: OSStatus = SecItemDelete(query as CFDictionary)
+        switch status {
+        case noErr, errSecItemNotFound, errSecSuccess:
+            return true
+        default:
+            return false
+        }
+    }
 }


### PR DESCRIPTION
We already delete all keychain items of the type `kSecClassGenericPassword`. This PR deletes items of tye `kSecClassKey` on app start. This allows for a testable update simulation. 