### PR TITLE
Add display logic for serological test

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "25df2a8980d995cc2a5c789c573935484dbbd59c",
+          "revision": "d66685c5463421cac7e6636ef73f429efb1331db",
           "version": null
         }
       },

--- a/Wallet/Screens/Certificates/CertificateDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailView.swift
@@ -161,7 +161,12 @@ class CertificateDetailView: UIView {
         else { return }
 
         addDividerLine()
-        addTitle(title: UBLocalized.translationWithEnglish(key: .covid_certificate_test_title_key))
+
+        if tests[0].isSerologicalTest {
+            addTitle(title: UBLocalized.translationWithEnglish(key: .covid_certificate_sero_positiv_test_title_key))
+        } else {
+            addTitle(title: UBLocalized.translationWithEnglish(key: .covid_certificate_test_title_key))
+        }
 
         for test in tests {
             addDividerLine()
@@ -179,8 +184,10 @@ class CertificateDetailView: UIView {
 
             addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_result_title_key), value: text)
 
-            addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_type_key), value: test.testType)
-            addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_holder_and_name_key), value: test.manufacturerAndTestName)
+            if !test.isSerologicalTest {
+                addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_type_key), value: test.testType)
+                addValueItem(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_test_holder_and_name_key), value: test.manufacturerAndTestName)
+            }
 
             addDividerLine()
 


### PR DESCRIPTION
This pull-request makes sure we show the new antibody-recovery certificate as "Recovery" (and not test).