### PR TITLE
Start with "timeshiftDetectionEnabled" = false in pre-bundled config

### DIFF
--- a/CovidCertificate/Resources/Config/config_wallet.json
+++ b/CovidCertificate/Resources/Config/config_wallet.json
@@ -682,7 +682,7 @@
     },
     "androidTransferCheckIntervalMs": 7200000,
     "androidTransferCheckBackoffMs": 30000,
-    "timeshiftDetectionEnabled": true,
+    "timeshiftDetectionEnabled": false,
     "transferQuestions": {
         "de": {
             "faqTitle": "Covid-Zertifikate direkt in die App geliefert",


### PR DESCRIPTION
This pull-request makes sure we start with timeshiftDetectionEnabled = false directly after initial installation. Will be enabled after the first config update (if enabled on backend).