### PR TITLE
Certificate detail state problems

### DIFF
--- a/Wallet/Screens/Certificates/CertificateDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailView.swift
@@ -15,8 +15,10 @@ import Foundation
 class CertificateDetailView: UIView {
     public var certificate: UserCertificate? {
         didSet {
-            setup()
-            update(animated: true)
+            if oldValue != certificate {
+                setup()
+                update(animated: true)
+            }
         }
     }
 
@@ -25,7 +27,11 @@ class CertificateDetailView: UIView {
     private let stackView = UIStackView()
 
     var states: (state: VerificationState, temporaryVerifierState: TemporaryVerifierState) = (.loading, .idle) {
-        didSet { update(animated: true) }
+        didSet {
+            if oldValue != states {
+                update(animated: true)
+            }
+        }
     }
 
     private let showEnglishLabels: Bool

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -44,12 +44,16 @@ class CertificateDetailViewController: ViewController {
 
     private var state: VerificationState = .loading {
         didSet {
-            update()
+            if oldValue != state {
+                update()
+            }
         }
     }
 
     private var temporaryVerifierState: TemporaryVerifierState = .idle {
         didSet {
+            guard oldValue != temporaryVerifierState else { return }
+
             UIView.animate(withDuration: 0.2) {
                 self.qrCodeStateView.state = self.temporaryVerifierState
             }
@@ -69,7 +73,11 @@ class CertificateDetailViewController: ViewController {
     }
 
     public var certificate: UserCertificate? {
-        didSet { updateCertificate() }
+        didSet {
+            if oldValue != certificate {
+                updateCertificate()
+            }
+        }
     }
 
     init(certificate: UserCertificate) {

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -183,6 +183,7 @@ class CertificateDetailViewController: ViewController {
             make.bottom.equalTo(view.safeAreaLayoutGuide).inset(Padding.large)
             make.trailing.equalTo(view.safeAreaLayoutGuide).inset(Padding.large + Padding.small)
         }
+        verifyButton.alpha = 0
 
         update()
     }
@@ -286,12 +287,13 @@ class CertificateDetailViewController: ViewController {
         guard let qrCode = certificate?.qrCode else { return }
 
         state = .loading
+        verifyButton.alpha = 0
 
         VerifierManager.shared.addObserver(self, for: qrCode) { [weak self] state in
-            guard let strongSelf = self else { return }
-            strongSelf.qrCodeStateView.alpha = 0
-            strongSelf.verifyButton.alpha = 1
-            strongSelf.state = state
+            guard let self = self else { return }
+            self.qrCodeStateView.alpha = 0
+            self.verifyButton.alpha = state == .loading ? 0 : 1
+            self.state = state
         }
     }
 

--- a/Wallet/Screens/Certificates/CertificateQRCodeStateView.swift
+++ b/Wallet/Screens/Certificates/CertificateQRCodeStateView.swift
@@ -17,7 +17,9 @@ class CertificateQRCodeStateView: UIView {
 
     var state: TemporaryVerifierState {
         didSet {
-            updateBackground(animated: state != .verifying)
+            if oldValue != state {
+                updateBackground(animated: state != .verifying)
+            }
         }
     }
 

--- a/Wallet/Screens/Certificates/CertificateStateView.swift
+++ b/Wallet/Screens/Certificates/CertificateStateView.swift
@@ -29,7 +29,11 @@ class CertificateStateView: UIView {
     private let hasValidityView: Bool
 
     var states: (state: VerificationState, temporaryVerifierState: TemporaryVerifierState) = (.loading, .idle) {
-        didSet { update(animated: true) }
+        didSet {
+            if oldValue != states {
+                update(animated: true)
+            }
+        }
     }
 
     private let isHomescreen: Bool


### PR DESCRIPTION
This PR fixes some state problems that could occur in the certificate detail view, when multiple check operations were running simultaneously (e.g. when the user opened a certificate while a check operation on the homescreen was still in progress, and then pressed the refresh button).

Furthermore, many UI update calls are reduced to the minimum by only calling them when the state has actually changed. This also fixes a UI bug where the refresh rotate animation would stop before the refresh was actually done.