### PR TITLE
Use isSwitzerlandOnly flag from display rules

### DIFF
--- a/CovidCertificate.xcodeproj/project.pbxproj
+++ b/CovidCertificate.xcodeproj/project.pbxproj
@@ -2730,7 +2730,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/admin-ch/CovidCertificate-SDK-iOS";
 			requirement = {
-				branch = main;
+				branch = "feature/ch-only-display-rule";
 				kind = branch;
 			};
 		};

--- a/CovidCertificate.xcodeproj/project.pbxproj
+++ b/CovidCertificate.xcodeproj/project.pbxproj
@@ -2730,7 +2730,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/admin-ch/CovidCertificate-SDK-iOS";
 			requirement = {
-				branch = "feature/ch-only-display-rule";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
         "package": "CovidCertificateSDK",
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
-          "branch": "feature/ch-only-display-rule",
-          "revision": "11a523495daf112e2adbc9f53d6d953a27471b9a",
+          "branch": "main",
+          "revision": "b54006a471eb3388af517459655ff9f5488ba9c4",
           "version": null
         }
       },

--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
         "package": "CovidCertificateSDK",
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
-          "branch": "main",
-          "revision": "0aa6da760d328af33d306b60f8ae64d65ccb54e7",
+          "branch": "feature/ch-only-display-rule",
+          "revision": "11a523495daf112e2adbc9f53d6d953a27471b9a",
           "version": null
         }
       },

--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -271,9 +271,9 @@ class Verifier: NSObject {
             var validUntil: String?
             var isSwitzerlandOnly: Bool?
 
-            // get expired date string
-            if let date = result.validUntil {
-                #if WALLET
+            #if WALLET
+                // get expired date string
+                if let date = result.validUntil {
                     switch (holder.certificate as? DCCCert)?.immunisationType {
                     case .test:
                         validUntil = DateFormatter.ub_dayTimeString(from: date)
@@ -284,10 +284,12 @@ class Verifier: NSObject {
                     case .none:
                         break
                     }
+                }
 
-                    isSwitzerlandOnly = holder.certificate.isSwitzerlandOnly
-                #endif
-            }
+                if let chOnly = result.isSwitzerlandOnly {
+                    isSwitzerlandOnly = chOnly
+                }
+            #endif
 
             // check for validity
             if result.isValid {

--- a/Wallet/Screens/Certificates/CertificateAddDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateAddDetailView.swift
@@ -75,12 +75,10 @@ class CertificateAddDetailView: UIView {
         let nameLabel = Label(.title, textAlignment: .center)
         let birthdayLabel = Label(.text, textAlignment: .center)
 
-        var certificateHolder: CertificateHolder?
         if let qrCode = certificate?.qrCode {
             let c = CovidCertificateSDK.Wallet.decode(encodedData: qrCode)
             switch c {
             case let .success(holder):
-                certificateHolder = holder
                 nameLabel.text = holder.certificate.displayFullName
                 birthdayLabel.text = holder.certificate.dateOfBirthFormatted
                 birthdayLabel.accessibilityLabel = DateFormatter.ub_accessibilityDateString(dateString: holder.certificate.dateOfBirthFormatted) ?? birthdayLabel.text
@@ -98,7 +96,7 @@ class CertificateAddDetailView: UIView {
         if let cert = certificate {
             let v = CertificateDetailView(showEnglishLabelsIfNeeded: false)
             v.certificate = cert
-            v.states = (.success(nil, certificateHolder?.certificate.isSwitzerlandOnly ?? false), .idle)
+            v.states = (.success(nil, false), .idle)
             stackScrollView.addArrangedView(v)
         }
 

--- a/Wallet/Screens/Certificates/CertificateAddDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateAddDetailView.swift
@@ -96,7 +96,6 @@ class CertificateAddDetailView: UIView {
         if let cert = certificate {
             let v = CertificateDetailView(showEnglishLabelsIfNeeded: false)
             v.certificate = cert
-            v.states = (.success(nil, false), .idle)
             stackScrollView.addArrangedView(v)
         }
 

--- a/Wallet/Screens/Certificates/CertificateDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailView.swift
@@ -330,27 +330,27 @@ class CertificateDetailView: UIView {
     }
 
     // MARK: - Update
-    
+
     func updateLabelColors(for states: (state: VerificationState, temporaryVerifierState: TemporaryVerifierState), animated: Bool) {
         let color: UIColor
-        
+
         switch states {
         case (_, .success),
-            (.success, .idle),
-            (.skipped, .idle):
+             (.success, .idle),
+             (.skipped, .idle):
             color = .cc_text
         default:
             color = .cc_grey
         }
-        
+
         setLabelsToColor(color, animated: animated)
     }
-    
+
     private func setLabelsToColor(_ color: UIColor, animated: Bool) {
         let actions = {
             self.labels.forEach { $0.textColor = color }
         }
-        
+
         if animated {
             UIView.animate(withDuration: 0.2) { actions() }
         } else {

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -326,7 +326,7 @@ class CertificateDetailViewController: ViewController {
 
     private func update() {
         stateView.states = (state, temporaryVerifierState)
-        detailView.states = (state, temporaryVerifierState)
+        detailView.updateLabelColors(for: (state, temporaryVerifierState), animated: true)
         qrCodeNameView.enabled = temporaryVerifierState != .idle || !state.isInvalid()
 
         exportRow.isEnabled = false


### PR DESCRIPTION
In the last release, a flag called `isSwitzerlandOnly` was introduced in the SDK that exposed whether a specific certificate was only valid in Switzerland. This flag is used to display additional information to the user in the wallet app. The rules of whether to show this flag were hardcoded in the SDK, so far returning true for light certificates and serological tests.

This PR changes the behaviour so that the `isSwitzerlandOnly` flag is now computed with the display rules, which makes it more flexible since the rules can be updated from the backend.