### PR TITLE
Verifier: Keep torch on while in verification screen

### DIFF
--- a/CovidCertificate/SharedUI/Views/QRScanner/NSQRScanningView.swift
+++ b/CovidCertificate/SharedUI/Views/QRScanner/NSQRScanningView.swift
@@ -29,7 +29,7 @@ class QRScannerView: UIView {
     var captureSession: AVCaptureSession?
 
     private var lampOn: Bool
-    
+
     /// When this is set to true, the capture session keeps running but no output is processed.
     /// One difference to stopping the scanning completely is that the torch can still be kept on while paused.
     private var isScanningPaused: Bool = true
@@ -83,7 +83,7 @@ extension QRScannerView {
         lampOn = on
         try? camera.setLight(on: lampOn)
     }
-    
+
     func pauseScanning() {
         isScanningPaused = true
     }
@@ -162,7 +162,7 @@ extension QRScannerView: AVCaptureMetadataOutputObjectsDelegate {
                         from _: AVCaptureConnection)
     {
         guard !isScanningPaused else { return } // Don't process any input if scanning is paused
-        
+
         if let metadataObject = metadataObjects.first {
             guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
             guard let stringValue = readableObject.stringValue else { return }

--- a/Verifier/Screens/Check/VerifyScannerViewController.swift
+++ b/Verifier/Screens/Check/VerifyScannerViewController.swift
@@ -192,7 +192,7 @@ extension VerifyScannerViewController: QRScannerViewDelegate {
 
             switch result {
             case let .success(holder):
-                qrView?.stopScanning()
+                qrView?.pauseScanning()
 
                 let feedback = UIImpactFeedbackGenerator(style: .heavy)
                 feedback.impactOccurred()


### PR DESCRIPTION
This PR changes the behaviour of the torch for the verifier app: If turned on during scanning, the torch now stays on while the user is in the verification screen.

This was requested from people who use the app in dark surroundings and who would like to use the torch to look at the identification card (ID) or similar, after scanning the certificate.