### PR TITLE
Fix error handling of revocation verification 

### DIFF
--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -256,7 +256,7 @@ class Verifier: NSObject {
             case .TIME_INCONSISTENCY:
                 return .retry(.timeShift, [err.errorCode])
             default:
-                return .invalid(errors: [.revocation], errorCodes: [err.errorCode], validity: nil, wasRevocationSkipped: false)
+                return .retry(.unknown, [err.errorCode])
             }
         }
     }


### PR DESCRIPTION
to show correct message and allow retry (instead of showing "revoked" even if it's not on the revocation list)