### PR TITLE
Fixes initialization of sdk

### DIFF
--- a/Verifier/Logic/AppDelegate.swift
+++ b/Verifier/Logic/AppDelegate.swift
@@ -30,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             isFirstLaunch = false
         }
 
+        CovidCertificateSDK.initialize(environment: Environment.current.sdkEnvironment, apiKey: Environment.current.appToken)
+
         // Reset keychain on first launch
         if isFirstLaunch {
             Keychain().deleteAll()
@@ -41,8 +43,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // no onboarding: so directly complete it here (so that the
         // isFirstLaunch still works)
         VerifierUserStorage.shared.hasCompletedOnboarding = true
-
-        CovidCertificateSDK.initialize(environment: Environment.current.sdkEnvironment, apiKey: Environment.current.appToken)
 
         SDKOptionsManager.updateSDKOptions()
 

--- a/Wallet/Logic/AppDelegate.swift
+++ b/Wallet/Logic/AppDelegate.swift
@@ -31,6 +31,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             isFirstLaunch = false
         }
 
+        CovidCertificateSDK.initialize(environment: Environment.current.sdkEnvironment, apiKey: Environment.current.appToken)
+
         // Reset keychain on first launch
         if isFirstLaunch {
             Keychain().deleteAll()
@@ -38,8 +40,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             CertificateStorage.shared.removeAll()
             isFirstLaunch = false
         }
-
-        CovidCertificateSDK.initialize(environment: Environment.current.sdkEnvironment, apiKey: Environment.current.appToken)
 
         // migrates certificates from keychain to secure storage
         Migration.migrateToSecureStorage()


### PR DESCRIPTION
Since the "currentNodes" of the SDK is also used in the UIState, the SDK needs to be initialized at the start such that any change to the UIState will not trigger a crash of the instancePrecondition() in the SDK.

E.g. on a clean install the wallet app deletes all certificates, this triggers a state update.