### PR TITLE
Only Refresh Transfercode if not expired

### DIFF
--- a/Wallet/Screens/Certificates/WalletDetailViewController.swift
+++ b/Wallet/Screens/Certificates/WalletDetailViewController.swift
@@ -106,10 +106,10 @@ class WalletDetailViewController: ViewController {
     // MARK: - Download
 
     private func startDownloadIfNeeded(forceUpdate: Bool = false) {
-        // only start if it's a not failed transfer-code
+        // only start if it's a valid transfercode (not expired or failed)
         guard certificate.type == .transferCode,
               let transferCode = certificate.transferCode,
-              transferCode.state != .failed
+              transferCode.state == .valid
         else { return }
 
         lightCertificateDetailVC.view.alpha = 0.0
@@ -152,7 +152,7 @@ class WalletDetailViewController: ViewController {
     private func updateLastLoad() {
         guard certificate.type == .transferCode,
               let transferCode = certificate.transferCode,
-              transferCode.state != .failed
+              transferCode.state == .valid
         else { return }
 
         if let lastLoad = TransferManager.shared.getLastLoad(code: transferCode.transferCode) {

--- a/Wallet/Screens/Homescreen/HomescreenCertificatesViewController.swift
+++ b/Wallet/Screens/Homescreen/HomescreenCertificatesViewController.swift
@@ -154,7 +154,7 @@ class HomescreenCertificatesViewController: ViewController {
                     i?.verificationState = state
                 }
             } else if let transferCode = i.certificate?.transferCode,
-                      transferCode.state != .failed // only start when not already failed
+                      transferCode.state == .valid // only start when still valid (not failed and not expired)
             {
                 TransferManager.shared.addObserver(self, for: transferCode.transferCode) { [weak i] result in
                     guard let strongI = i else { return }


### PR DESCRIPTION
After a transfer-code expired (30+3 days currently), the app doesn't make any new requests to the backend (they are deleted in the DB anyways)