### PR TITLE
2G+ check fixes

### DIFF
--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -141,6 +141,16 @@ enum VerificationState: Equatable {
             return nil
         }
     }
+
+    public func getFirstError() -> VerificationError? {
+        switch self {
+        case let .invalid(errors, _, _, _):
+            let (signatureError, revocationError, nationalError) = getVerifierErrorState() ?? (nil, nil, nil)
+            return signatureError ?? revocationError ?? nationalError ?? errors.first
+        default:
+            return nil
+        }
+    }
 }
 
 class Verifier: NSObject {

--- a/Verifier/Screens/Check/VerifyCheckContentViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckContentViewController.swift
@@ -237,11 +237,9 @@ class VerifyCheckContentViewController: ViewController {
                              showReloadButton: false)
             }
 
-        case let .invalid(errors, errorCodes, _, _):
-            let (signatureError, revocationError, nationalError) = state?.getVerifierErrorState() ?? (nil, nil, nil)
+        case let .invalid(_, errorCodes, _, _):
+            let error = state?.getFirstError()
 
-            // errors can never be empty in invalid state, therefore one optional will always safely unwrap
-            let error: VerificationError? = signatureError ?? revocationError ?? nationalError ?? errors.first
             let text: NSAttributedString = error?.displayName() ?? NSAttributedString(string: "")
 
             switch error {
@@ -307,10 +305,11 @@ class VerifyCheckContentViewController: ViewController {
                 self.infoErrorView2.ub_setHidden(true)
 
             case .invalid:
-                let (signatureError, revocationError, nationalError) = self.state?.getVerifierErrorState() ?? (nil, nil, nil)
+                let (signatureError, revocationError, _) = self.state?.getVerifierErrorState() ?? (nil, nil, nil)
+                let error = self.state?.getFirstError()
 
                 var isError = false
-                if let n = nationalError {
+                if let n = error {
                     switch n {
                     case .unknown, .lightUnsupported:
                         isError = true

--- a/Verifier/Screens/Check/VerifyCheckContentViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckContentViewController.swift
@@ -309,7 +309,7 @@ class VerifyCheckContentViewController: ViewController {
             case .invalid:
                 let (signatureError, revocationError, nationalError) = self.state?.getVerifierErrorState() ?? (nil, nil, nil)
 
-                var isError = true
+                var isError = false
                 if let n = nationalError {
                     switch n {
                     case .unknown, .lightUnsupported:

--- a/Verifier/Screens/Check/VerifyCheckContentViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckContentViewController.swift
@@ -201,7 +201,7 @@ class VerifyCheckContentViewController: ViewController {
                 let successImage = isPlus ? UIImage(named: "ic-plus-outline") : UIImage(named: "ic_2g")
                 statusView.set(text: successText.bold(), backgroundColor: .cc_greenish, icon: successImage?.ub_image(with: UIColor.cc_green))
 
-                let infoText = isPlus ? UBLocalized.verifier_2g_plus_infoplus : UBLocalized.verifier_2g_plus_info2g
+                let infoText = !isPlus ? UBLocalized.verifier_2g_plus_infoplus : UBLocalized.verifier_2g_plus_info2g
 
                 let infoImage = !isPlus ? UIImage(named: "ic-plus-outline") : UIImage(named: "ic_2g")
                 infoView.set(text: infoText, backgroundColor: .cc_greyish, icon: infoImage?.ub_image(with: .cc_grey), showReloadButton: false)

--- a/Verifier/Screens/Check/VerifyCheckViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckViewController.swift
@@ -205,10 +205,8 @@ class VerifyCheckViewController: ViewController {
                 self.imageView.image = UIImage(named: "ic-header-valid")
                 self.backgroundView.backgroundColor = .cc_green
             case .invalid:
-                let (_, _, nationalError) = self.state.getVerifierErrorState() ?? (nil, nil, nil)
-
                 var isError = true
-                if let n = nationalError {
+                if let n = self.state.getFirstError() {
                     switch n {
                     case .unknown, .lightUnsupported:
                         isError = false


### PR DESCRIPTION
- Fixes info text in 2G+ success case
- Fixes wrong initialization of isError for invalid cases
- Check the first error, not the national error only