### PR TITLE
fixes the vaccination label for certificates where doseNumber is greater than totalDoses

### DIFF
--- a/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
+++ b/CovidCertificate/SharedLogic/Helpers/EuHealthCert+CC.swift
@@ -105,6 +105,12 @@ extension Vaccination {
     }
 }
 
+extension Array where Element == Vaccination {
+    var isComplete: Bool {
+        allSatisfy { $0.doseNumber >= $0.totalDoses }
+    }
+}
+
 extension PastInfection {
     var displayCountry: String {
         return Locale.current.localizedString(forRegionCode: countryOfTest) ?? countryOfTest

--- a/Wallet/Screens/Certificates/CertificateDetailView.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailView.swift
@@ -88,7 +88,7 @@ class CertificateDetailView: UIView {
             addDividerLine()
         }
 
-        if vaccinations.allSatisfy({ $0.doseNumber == $0.totalDoses }) {
+        if vaccinations.isComplete {
             addTitle(title: UBLocalized.translationWithEnglish(key: .covid_certificate_vaccination_title_key))
         } else {
             addTitle(title: UBLocalized.translationWithEnglish(key: .wallet_certificate_type_incomplete_vaccine_key))

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -266,7 +266,7 @@ class CertificateDetailViewController: ViewController {
         case let .success(holder):
             guard let certificate = holder.certificate as? DCCCert else { break }
             let vaccinations = certificate.vaccinations ?? []
-            if !vaccinations.allSatisfy({ $0.doseNumber == $0.totalDoses }) {
+            if !vaccinations.isComplete {
                 title = UBLocalized.wallet_certificate_evidence_title.uppercased()
             }
         case .failure:

--- a/Wallet/Screens/Homescreen/HomescreenCertificateView.swift
+++ b/Wallet/Screens/Homescreen/HomescreenCertificateView.swift
@@ -203,7 +203,7 @@ class HomescreenCertificateView: UIView {
             case let .success(holder):
                 guard let certificate = holder.certificate as? DCCCert else { break }
                 let vaccinations = certificate.vaccinations ?? []
-                if vaccinations.allSatisfy({ $0.doseNumber == $0.totalDoses }) {
+                if vaccinations.isComplete {
                     titleLabel.text = UBLocalized.wallet_certificate
                 } else {
                     titleLabel.text = UBLocalized.wallet_certificate_evidence_title


### PR DESCRIPTION
this resolved issue #247

Android Implementation: https://github.com/admin-ch/CovidCertificate-SDK-Kotlin/blob/7b491f1b37f6f95f4ae63d3144f3c960738ff809/src/main/java/ch/admin/bag/covidcertificate/sdk/core/extensions/VaccinationEntryExtensions.kt#L36-L38