### PR TITLE
Update SDK 

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "7e56324a4a18cb532b1dd4d47f2d7d285747f87f",
+          "revision": "c2253d2e867f98a9b376b182534a6abcf022aa1f",
           "version": null
         }
       },


### PR DESCRIPTION
that includes the pre-packaged revocation list (https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/129)