### PR TITLE
Update SDK

### DIFF
--- a/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CovidCertificate.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/admin-ch/CovidCertificate-SDK-iOS",
         "state": {
           "branch": "main",
-          "revision": "e0ad195bae65996b74466cfb2c26836c2d05a792",
+          "revision": "9c27c5b7fe74c024cd257c95658711e569c4084d",
           "version": null
         }
       },


### PR DESCRIPTION
- which includes https://github.com/admin-ch/CovidCertificate-SDK-iOS/pull/136