### PR TITLE
Don't allow ch-certificates to show foreign check button if invalid

### DIFF
--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -241,7 +241,7 @@ class Verifier: NSObject {
         var errorCodes = states.compactMap { $0.errorCodes() }.flatMap { $0 }
         errorCodes.sort()
 
-        var isSwitzerlandOnly: Bool? = nil
+        var isSwitzerlandOnly: Bool?
         switch checkNationalRulesState {
         case let .success(_, switzerlandOnly, _, _):
             isSwitzerlandOnly = switzerlandOnly

--- a/CovidCertificate/SharedLogic/Verifier/Verifier.swift
+++ b/CovidCertificate/SharedLogic/Verifier/Verifier.swift
@@ -435,7 +435,7 @@ class Verifier: NSObject {
             #if WALLET
                 return .invalid(errors: [.otherNationalRules("")], errorCodes: error, validity: nil, wasRevocationSkipped: false, switzerlandOnly: nil)
             #elseif VERIFIER
-                return .invalid(errors: [.otherNationalRules(modes?.first?.displayName ?? "")], errorCodes: [], validity: nil, wasRevocationSkipped: false)
+                return .invalid(errors: [.otherNationalRules(modes?.first?.displayName ?? "")], errorCodes: [], validity: nil, wasRevocationSkipped: false, switzerlandOnly: nil)
             #endif
         }
     }

--- a/Verifier/Screens/Check/VerifyCheckContentViewController.swift
+++ b/Verifier/Screens/Check/VerifyCheckContentViewController.swift
@@ -237,7 +237,7 @@ class VerifyCheckContentViewController: ViewController {
                              showReloadButton: false)
             }
 
-        case let .invalid(_, errorCodes, _, _):
+        case let .invalid(_, errorCodes, _, _, _):
             let error = state?.getFirstError()
 
             let text: NSAttributedString = error?.displayName() ?? NSAttributedString(string: "")

--- a/Wallet/Screens/Certificates/Abroad/CertificateCheckAbroadVerificationStateView.swift
+++ b/Wallet/Screens/Certificates/Abroad/CertificateCheckAbroadVerificationStateView.swift
@@ -157,7 +157,7 @@ class CertificateCheckAbroadVerificationStateView: UIView {
                 self.textLabel.attributedText = text
                 self.imageView.image = UIImage(named: "ic-check-filled")
                 self.backgroundView.backgroundColor = .cc_greenish
-            case let .invalid(errors, errorCodes, _, _):
+            case let .invalid(errors, errorCodes, _, _, _):
                 let first = state.state.getFirstError()
 
                 self.imageView.image = first?.icon(with: .cc_red)

--- a/Wallet/Screens/Certificates/CertificateDetailViewController.swift
+++ b/Wallet/Screens/Certificates/CertificateDetailViewController.swift
@@ -437,6 +437,8 @@ class CertificateDetailViewController: ViewController {
         switch state {
         case let .success(_, switzerlandOnly, _, _):
             isSwitzerlandOnly = switzerlandOnly ?? false
+        case let .invalid(_, _, _, _, switzerlandOnly):
+            isSwitzerlandOnly = switzerlandOnly ?? false
         default:
             break
         }

--- a/Wallet/Screens/Certificates/CertificateStateView.swift
+++ b/Wallet/Screens/Certificates/CertificateStateView.swift
@@ -147,7 +147,7 @@ class CertificateStateView: UIView {
                 self.validityView.textColor = .cc_black
                 self.validityView.untilText = validUntil
             case .failure:
-                if case let .invalid(errors, errorCodes, validUntil, _) = self.states.state {
+                if case let .invalid(errors, errorCodes, validUntil, _, _) = self.states.state {
                     let first = self.states.state.getFirstError()
 
                     self.imageView.image = first?.icon(with: .cc_red)
@@ -221,7 +221,7 @@ class CertificateStateView: UIView {
                     self.validityView.textColor = .cc_black
                     self.validityView.untilText = validUntil
 
-                case let .invalid(errors, errorCodes, validUntil, _):
+                case let .invalid(errors, errorCodes, validUntil, _, _):
                     let first = self.states.state.getFirstError()
 
                     self.imageView.image = first?.icon()


### PR DESCRIPTION
Also propagate ch-only property for invalid certificate s.t. they can be identified. These certificates should not show the foreign check button on the detail.