### PR TITLE
fix broken url to openfont license

### DIFF
--- a/CovidCertificate/Supporting Files/Impressum/de/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/de/licence.html
@@ -27,7 +27,7 @@
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
 <li><a href="http://unlicense.org">The Unlicense</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/en/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/en/licence.html
@@ -27,7 +27,7 @@
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
 <li><a href="http://unlicense.org">The Unlicense</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/fr/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/fr/licence.html
@@ -27,7 +27,7 @@
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
 <li><a href="http://unlicense.org">The Unlicense</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/it/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/it/licence.html
@@ -27,7 +27,7 @@
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
 <li><a href="http://unlicense.org">The Unlicense</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>

--- a/CovidCertificate/Supporting Files/Impressum/rm/licence.html
+++ b/CovidCertificate/Supporting Files/Impressum/rm/licence.html
@@ -27,7 +27,7 @@
 <li><a href="https://opensource.org/licenses/MIT">MIT license</a></li>
 <li><a href="https://opensource.org/licenses/MPL-2.0">MPL 2 license</a></li>
 <li><a href="http://unlicense.org">The Unlicense</a></li>
-<li><a href="https://opensource.org/licenses/OFL-1.1">SIL OPEN FONT LICENSE</a></li>
+<li><a href="https://opensource.org/license/openfont-html">SIL OPEN FONT LICENSE</a></li>
 </ul>
     </div>
 </div>


### PR DESCRIPTION
The link to the "SIL OPEN FONT LICENSE (OFL-1.1)" is broken in the app. This pull request fixes the url